### PR TITLE
feat: impl EX stage

### DIFF
--- a/bonsai/emu/core.py
+++ b/bonsai/emu/core.py
@@ -905,7 +905,7 @@ class ExStage:
             action_bits=AfterExAction.STORE,
             mem_addr=store_op.mem_addr(),
             mem_size=store_op.mem_size(),
-            store_data=store_op.store_data(),
+            mem_data=store_op.store_data(),
         ), None
 
     @classmethod
@@ -965,6 +965,18 @@ class ExStage:
             branch_cond=branch_op.branch_cond(),
         ), None
 
+    def _run_u_lui(
+        cls, decode_data: IdStage.Result, reg_file: RegFile
+    ) -> Tuple[Optional["ExStage.Result"], ExceptionCode | None]:
+        # LUI: rd = imm[31:12]
+        imm = decode_data.operand.u.imm << 12
+        return ExStage.Result(
+            decode_data=decode_data.fetch_data,
+            action_bits=AfterExAction.WRITEBACK,
+            writeback_idx=decode_data.operand.u.rd,
+            writeback_data=imm,
+        ), None
+
     @classmethod
     def run(
         cls,
@@ -979,7 +991,7 @@ class ExStage:
             InstGroup.I_ARITHMETIC: cls._run_i_arithmetic,
             InstGroup.S_STORE: cls._run_s_store,
             InstGroup.B_BRANCH: cls._run_b_branch,
-            # InstFmt.U_LUI: cls._run_utype,
+            InstGroup.U_LUI: cls._run_u_lui,
             # InstFmt.U_AUIPC: cls._run_utype,
             # InstFmt.J_JAL: cls._run_jtype,
             # InstFmt.J_JALR: cls._run_jtype,
@@ -996,10 +1008,6 @@ class ExStage:
 
 
 class MemStage:
-    """
-    メモリアクセス
-    """
-
     @dataclass
     class Result:
         # ex result

--- a/bonsai/emu/core.py
+++ b/bonsai/emu/core.py
@@ -1018,7 +1018,7 @@ class ExStage:
             decode_data=decode_data.fetch_data,
             action_bits=AfterExAction.BRANCH | AfterExAction.WRITEBACK,
             writeback_idx=decode_data.operand.j.rd,
-            writeback_data=decode_data.fetch_data.pc + 4,
+            writeback_data=decode_data.fetch_data.pc + SysAddr.NUM_WORD_BYTES,
             branch_addr=decode_data.fetch_data.pc + imm,
             branch_cond=True,
         ), None
@@ -1037,10 +1037,20 @@ class ExStage:
             decode_data=decode_data.fetch_data,
             action_bits=AfterExAction.BRANCH | AfterExAction.WRITEBACK,
             writeback_idx=decode_data.operand.i.rd,
-            writeback_data=decode_data.fetch_data.pc + 4,
+            writeback_data=decode_data.fetch_data.pc + SysAddr.NUM_WORD_BYTES,
             branch_addr=src_regs.rs1 + decode_data.operand.i.imm_sext,
             branch_cond=True,
         ), None
+
+    @classmethod
+    def _run_r_atomic(
+        cls, decode_data: IdStage.Result, reg_file: RegFile
+    ) -> Tuple[Optional["ExStage.Result"], ExceptionCode | None]:
+        # TODO: implement
+        # - Aquire memory,  Release memory fieldの命令保証するためには Pipelineの状態確認が必要
+        # - LR/SCのためにメモリ予約とその確認が必要
+        # - Swap/Atomic XXX のために、MEM stageで読み出した値をWB stageまでに変更する必要がある
+        return None, ExceptionCode.ILLEGAL_INST
 
     @classmethod
     def run(
@@ -1060,8 +1070,8 @@ class ExStage:
             InstGroup.U_AUIPC: cls._run_u_auipc,
             InstGroup.J_JAL: cls._run_j_jal,
             InstGroup.J_JALR: cls._run_i_jalr,
+            InstGroup.R_ATOMIC: cls._run_r_atomic,
             # InstFmt.I_ENV: cls._run_itype,
-            # InstFmt.R_ATOMIC: cls._run_atomic,
         }
         execution_function = table.get(decode_data.inst_fmt, None)
         # 未定義命令

--- a/bonsai/emu/core.py
+++ b/bonsai/emu/core.py
@@ -977,6 +977,18 @@ class ExStage:
             writeback_data=imm,
         ), None
 
+    def _run_u_auipc(
+        cls, decode_data: IdStage.Result, reg_file: RegFile
+    ) -> Tuple[Optional["ExStage.Result"], ExceptionCode | None]:
+        # AUIPC: rd = pc + imm[31:12]
+        imm = decode_data.operand.u.imm << 12
+        return ExStage.Result(
+            decode_data=decode_data.fetch_data,
+            action_bits=AfterExAction.WRITEBACK,
+            writeback_idx=decode_data.operand.u.rd,
+            writeback_data=decode_data.fetch_data.pc + imm,
+        ), None
+
     @classmethod
     def run(
         cls,
@@ -992,7 +1004,7 @@ class ExStage:
             InstGroup.S_STORE: cls._run_s_store,
             InstGroup.B_BRANCH: cls._run_b_branch,
             InstGroup.U_LUI: cls._run_u_lui,
-            # InstFmt.U_AUIPC: cls._run_utype,
+            InstGroup.U_AUIPC: cls._run_u_auipc,
             # InstFmt.J_JAL: cls._run_jtype,
             # InstFmt.J_JALR: cls._run_jtype,
             # InstFmt.I_ENV: cls._run_itype,

--- a/bonsai/emu/emulator.py
+++ b/bonsai/emu/emulator.py
@@ -62,7 +62,9 @@ class MemEntry:
     def from_elffile(cls, elffile: ELFFile) -> List["MemEntry"]:
         dst = []
         for segment, section in zip(elffile.iter_segments(), elffile.iter_sections()):
-            logging.debug(f"type: {segment['p_type']} name: {section.name} {segment}")
+            logging.debug(
+                f"type: {segment['p_type']} name:{section.name} paddr:0x{segment['p_paddr']:016x} filesz:0x{segment['p_filesz']:016x} memsz:0x{segment['p_memsz']:016x} align:0x{segment['p_align']:08x}"
+            )
             if not segment["p_type"] == "PT_LOAD":
                 continue
             dst.append(

--- a/bonsai/emu/emulator.py
+++ b/bonsai/emu/emulator.py
@@ -1,10 +1,11 @@
 import argparse
+import enum
 import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List
 
-from elftools.elf.constants import SH_FLAGS
+from elftools.elf.constants import P_FLAGS
 from elftools.elf.elffile import ELFFile
 from rich import print
 
@@ -18,48 +19,56 @@ from bonsai.emu.mem import (
 )
 
 
+class RegionFlag(enum.Flag):
+    EXECUTABLE = enum.auto()
+    WRITABLE = enum.auto()
+    READABLE = enum.auto()
+
+    @classmethod
+    def from_p_flags(cls, flags: int) -> "RegionFlag":
+        dst = cls(0)
+        if flags & P_FLAGS.PF_X:
+            dst |= cls.EXECUTABLE
+        if flags & P_FLAGS.PF_W:
+            dst |= cls.WRITABLE
+        if flags & P_FLAGS.PF_R:
+            dst |= cls.READABLE
+        return dst
+
+
 @dataclass
-class MemorySegment:
-    section_name: str
-    type: str
-    offset: int
-    virt_addr: int
+class MemoryMap:
+    name: str
+    region: RegionFlag
     phys_addr: int
     file_size: int
     mem_size: int
-    flags: int
     align: int
     data: bytes = b""
 
     def __repr__(self) -> str:
         return (
-            f"ProgramHeader("
-            f"section_name='{self.section_name}', "
-            f"type='{self.type}', "
-            f"offset={hex(self.offset)}, "
-            f"virt_addr={hex(self.virt_addr)}, "
+            f"MemoryMap("
+            f"name='{self.name}', "
+            f"region={self.region}, "
             f"phys_addr={hex(self.phys_addr)}, "
             f"file_size={hex(self.file_size)}, "
             f"mem_size={hex(self.mem_size)}, "
-            f"flags={hex(self.flags)}, "
             f"align={hex(self.align)}"
             f")"
         )
 
     @classmethod
-    def from_elffile(cls, elffile: ELFFile) -> List["MemorySegment"]:
+    def from_elffile(cls, elffile: ELFFile) -> List["MemoryMap"]:
         dst = []
         for segment, section in zip(elffile.iter_segments(), elffile.iter_sections()):
             dst.append(
                 cls(
-                    section_name=section.name,
-                    type=segment["p_type"],
-                    offset=segment["p_offset"],
-                    virt_addr=segment["p_vaddr"],
+                    name=section.name,
+                    region=RegionFlag.from_p_flags(segment["p_flags"]),
                     phys_addr=segment["p_paddr"],
                     file_size=segment["p_filesz"],
                     mem_size=segment["p_memsz"],
-                    flags=segment["p_flags"],
                     align=segment["p_align"],
                     data=segment.data(),
                 )
@@ -71,7 +80,7 @@ class MemorySegment:
 class EmulatorBootInfo:
     entry_point_addr: int
     uart_start_addr: int
-    segments: List[MemorySegment]
+    segments: List[MemoryMap]
 
     @classmethod
     def from_elffile(
@@ -80,7 +89,7 @@ class EmulatorBootInfo:
         return cls(
             entry_point_addr=elffile.header["e_entry"],
             uart_start_addr=uart_start_addr,
-            segments=MemorySegment.from_elffile(elffile),
+            segments=MemoryMap.from_elffile(elffile),
         )
 
     @classmethod
@@ -132,16 +141,15 @@ class Emulator:
         for i, segment in enumerate(bootinfo.segments):
             if segment.type == "PT_LOAD":
                 # select write or read only
-                is_writable = (segment.flags & SH_FLAGS.SHF_WRITE) != 0
                 mem = (
                     FixSizeRam(
-                        name=f"ram{i}",
+                        name=f"ram{i}_{segment.name}",
                         size=segment.mem_size,
                         init_data=segment.data,
                     )
-                    if is_writable
+                    if segment.region & RegionFlag.WRITABLE
                     else FixSizeRom(
-                        name=f"rom{i}",
+                        name=f"rom{i}_{segment.name}",
                         size=segment.mem_size,
                         init_data=segment.data,
                     )

--- a/bonsai/emu/emulator.py
+++ b/bonsai/emu/emulator.py
@@ -84,6 +84,7 @@ class EmulatorBootInfo:
     entry_point_addr: int
     uart_start_addr: int
     mem_entries: List[MemEntry]
+    elffile: ELFFile | None = None
 
     @classmethod
     def from_elffile(
@@ -93,6 +94,7 @@ class EmulatorBootInfo:
             entry_point_addr=elffile.header["e_entry"],
             uart_start_addr=uart_start_addr,
             mem_entries=MemEntry.from_elffile(elffile),
+            elffile=elffile,
         )
 
     @classmethod

--- a/bonsai/emu/mem.py
+++ b/bonsai/emu/mem.py
@@ -559,7 +559,5 @@ class BusArbiter(BusSlave):
         dst += f" - size: {self.size} bytes\n"
         dst += f" - {len(self._entries)} entries\n"
         for i, entry in enumerate(self._entries):
-            dst += (
-                f"  - entry {i}: 0x{entry.start_addr:016x} {entry.slave.get_name()}\n"
-            )
+            dst += f"  - entry {i}: 0x{entry.start_addr:016x}-0x{entry.end_addr:016x} {entry.slave.get_name()} ({entry.size} bytes)\n"
         return dst


### PR DESCRIPTION
This pull request makes several significant changes to the `bonsai/emu/emulator.py` file, including the introduction of a new `RegionFlag` class, renaming and modifying the `MemorySegment` class, and updating methods to use the new class. Additionally, there are some changes to the `bonsai/emu/mem.py` file to improve the description output.

### Key Changes:

#### Introduction of `RegionFlag` Class:
* Added a new `RegionFlag` class to represent memory region flags using the `enum.Flag` class. This class includes methods to convert from ELF `P_FLAGS` to `RegionFlag`.

#### Modifications to `MemorySegment` Class:
* Renamed `MemorySegment` to `MemEntry` and updated its attributes to include the new `RegionFlag` class instead of raw flag integers.
* Updated the `from_elffile` method to use `MemEntry` and the new `RegionFlag` class for better readability and maintainability. [[1]](diffhunk://#diff-bab2eae2af0aa93235b9d8319dd0805f8576f8de71d387f65bce176d7e2358baL74-R89) [[2]](diffhunk://#diff-bab2eae2af0aa93235b9d8319dd0805f8576f8de71d387f65bce176d7e2358baL83-R99)

#### Updates to `EmulatorBootInfo`:
* Changed the `segments` attribute to `mem_entries` to reflect the renaming of `MemorySegment` to `MemEntry`.
* Updated the `describe` method to iterate over `mem_entries` instead of `segments`.

#### Other Improvements:
* Enhanced the `describe` method in `bonsai/emu/mem.py` to provide more detailed output for memory entries, including start and end addresses and entry sizes.